### PR TITLE
Add showfilename set option

### DIFF
--- a/common/options.c
+++ b/common/options.c
@@ -161,6 +161,8 @@ OPTLIST const optlist[] = {
         {"shiftwidth",  NULL,           OPT_NUM,        OPT_NOZERO},
 /* O_SHOWMATCH      4BSD */
         {"showmatch",   NULL,           OPT_0BOOL,      0},
+/* O_SHOWFILENAME */
+        {"showfilename",NULL,           OPT_0BOOL,      0},
 /* O_SHOWMODE     4.4BSD */
         {"showmode",    NULL,           OPT_0BOOL,      0},
 /* O_SIDESCROLL   4.4BSD */

--- a/docs/USD.doc/vi.man/vi.1
+++ b/docs/USD.doc/vi.man/vi.1
@@ -2529,6 +2529,10 @@ for
 and
 .Sq )\&
 characters.
+.It Cm showfilename Bq off
+.Nm vi
+only.
+Display the file name on the colon command line.
 .It Cm showmode , smd Bq off
 .Nm vi
 only.

--- a/vi/vs_refresh.c
+++ b/vi/vs_refresh.c
@@ -819,7 +819,8 @@ vs_modeline(SCR *sp)
 
         /* If windowname is set, or >1 screen exists, then show the name */
         curlen = 0;
-        if ((IS_SPLIT(sp)) || O_ISSET(sp, O_WINDOWNAME)) {
+        if ((IS_SPLIT(sp)) || O_ISSET(sp, O_WINDOWNAME) ||
+	    O_ISSET(sp, O_SHOWFILENAME)) {
                 for (p = sp->frp->name; *p != '\0'; ++p);
                 for (ellipsis = 0, cols = sp->cols / 2; --p > sp->frp->name;) {
                         if (*p == '/') {


### PR DESCRIPTION
Pressing control-G all the time to understand 'what file is in what window' might be tedious. Instead, offer a configurable set option (default off) to display the file name in the lower left corner.

Taken from the OpenBSD vi implementation.