### PR TITLE
Fix symlink targets containing DESTDIR

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -656,10 +656,10 @@ endif # DEBUG
 	@$(VERBOSE); $(CP) "docs/USD.doc/vi.man/vi.1"                       \
         "$(DESTDIR)$(PREFIX)/share/man/man1/$(BINPREFIX)vi$(BINSUFFIX).1"   \
          && $(LNS)                                                          \
-        "$(DESTDIR)$(PREFIX)/share/man/man1/$(BINPREFIX)vi$(BINSUFFIX).1"   \
+        "$(PREFIX)/share/man/man1/$(BINPREFIX)vi$(BINSUFFIX).1"   \
         "$(DESTDIR)$(PREFIX)/share/man/man1/$(BINPREFIX)view$(BINSUFFIX).1" \
          && $(LNS)                                                          \
-        "$(DESTDIR)$(PREFIX)/share/man/man1/$(BINPREFIX)vi$(BINSUFFIX).1"   \
+        "$(PREFIX)/share/man/man1/$(BINPREFIX)vi$(BINSUFFIX).1"   \
         "$(DESTDIR)$(PREFIX)/share/man/man1/$(BINPREFIX)ex$(BINSUFFIX).1"
 ifndef DEBUG
 	-@$(PRINTF) "\r\t%s\t%42s\n" \


### PR DESCRIPTION
Symlink targets should never contain `DESTDIR` only `PREFIX`.

Fixes https://github.com/johnsonjh/OpenVi/commit/c60a6bd825d6ab5ba8322979852365c93d0ea852