### PR TITLE
Fix filename completion on MacOS

### DIFF
--- a/ex/ex_argv.c
+++ b/ex/ex_argv.c
@@ -502,7 +502,7 @@ argv_lexp(SCR *sp, EXCMD *excp, char *path)
                 }
                 name = p + 1;
         }
-        nlen = strlen(name) + 2;
+        nlen = strlen(name);
 
         if ((dirp = opendir(dname)) == NULL) {
                 msgq_str(sp, M_SYSERR, dname, "%s");
@@ -513,23 +513,22 @@ argv_lexp(SCR *sp, EXCMD *excp, char *path)
                         if (dp->d_name[0] == '.')
                                 continue;
                 } else {
-                        if (memcmp(dp->d_name, name, nlen))
+                        if (dp->d_namlen < nlen ||
+                            memcmp(dp->d_name, name, nlen))
                                 continue;
                 }
 
                 /* Directory + name + slash + NULL. */
-                argv_alloc(sp, dlen + nlen + 2);
+                argv_alloc(sp, dlen + dp->d_namlen + 2);
                 p = exp->args[exp->argsoff]->bp;
-                if (p == NULL)
-                        return (1);
                 if (dlen != 0) {
                         memcpy(p, dname, dlen);
                         p += dlen;
                         if (dlen > 1 || dname[0] != '/')
                                 *p++ = '/';
                 }
-                memcpy(p, dp->d_name, nlen + 1);
-                exp->args[exp->argsoff]->len = dlen + nlen + 1;
+                memcpy(p, dp->d_name, dp->d_namlen + 1);
+                exp->args[exp->argsoff]->len = dlen + dp->d_namlen + 1;
                 ++exp->argsoff;
                 excp->argv = exp->args;
                 excp->argc = exp->argsoff;


### PR DESCRIPTION
Revert to OpenBSD version of argv_lexp

Fix for https://github.com/johnsonjh/OpenVi/issues/22

Not entirely sure where the problem is, I think it's in adding 2 to nlen.
In the following checks, nlen will never be 0 and the memcmp might be looking at 2 extra random characters that will likely never match.