### PR TITLE
fix filename completion

### DIFF
--- a/ex/ex_argv.c
+++ b/ex/ex_argv.c
@@ -502,7 +502,7 @@ argv_lexp(SCR *sp, EXCMD *excp, char *path)
                 }
                 name = p + 1;
         }
-        nlen = strlen(name) + 2;
+        nlen = strlen(name);
 
         if ((dirp = opendir(dname)) == NULL) {
                 msgq_str(sp, M_SYSERR, dname, "%s");
@@ -513,23 +513,22 @@ argv_lexp(SCR *sp, EXCMD *excp, char *path)
                         if (dp->d_name[0] == '.')
                                 continue;
                 } else {
-                        if (memcmp(dp->d_name, name, nlen))
+                        if (D_NAMLEN(dp) < nlen ||
+                            memcmp(dp->d_name, name, nlen))
                                 continue;
                 }
 
                 /* Directory + name + slash + NULL. */
-                argv_alloc(sp, dlen + nlen + 2);
+                argv_alloc(sp, dlen + D_NAMLEN(dp) + 2);
                 p = exp->args[exp->argsoff]->bp;
-                if (p == NULL)
-                        return (1);
                 if (dlen != 0) {
                         memcpy(p, dname, dlen);
                         p += dlen;
                         if (dlen > 1 || dname[0] != '/')
                                 *p++ = '/';
                 }
-                memcpy(p, dp->d_name, nlen + 1);
-                exp->args[exp->argsoff]->len = dlen + nlen + 1;
+                memcpy(p, dp->d_name, D_NAMLEN(dp) + 1);
+                exp->args[exp->argsoff]->len = dlen + D_NAMLEN(dp) + 1;
                 ++exp->argsoff;
                 excp->argv = exp->args;
                 excp->argc = exp->argsoff;


### PR DESCRIPTION
Revert to OpenBSD version in `argv_lexp`, using the portable marco `D_NAMLEN` defined in `include/compat.h`.
The problem of the OpenBSD code and #42 is that `(struct dirent *)->d_namlen` is not portable. The BSD's including MacOS have `d_namlen`, but Linux has only `d_reclen`. The macro `D_NAMLEN` handles them both.

Fixes #22.