### PR TITLE
Attempt to fix compilation problem on Linux with termios

### DIFF
--- a/cl/cl_funcs.c
+++ b/cl/cl_funcs.c
@@ -33,7 +33,12 @@
 #include <signal.h>
 #include <bsd_termios.h>
 #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
 # include <termio.h>
+#endif
 #endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 #include <bsd_unistd.h>
 

--- a/cl/cl_main.c
+++ b/cl/cl_main.c
@@ -36,8 +36,13 @@
 #include <term.h>
 #include <bsd_termios.h>
 #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
 # include <termio.h>
-#endif /* #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
+#endif
+#endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 #include <bsd_unistd.h>
 
 #include "errc.h"

--- a/cl/cl_read.c
+++ b/cl/cl_read.c
@@ -43,7 +43,12 @@
 
 #include <bsd_termios.h>
 #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
 # include <termio.h>
+#endif
 #endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 #include <bsd_unistd.h>
 

--- a/cl/cl_screen.c
+++ b/cl/cl_screen.c
@@ -32,8 +32,13 @@
 #include <term.h>
 #include <bsd_termios.h>
 #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
 # include <termio.h>
-#endif /* #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
+#endif
+#endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 #include <bsd_unistd.h>
 
 #include "../common/common.h"

--- a/cl/cl_term.c
+++ b/cl/cl_term.c
@@ -33,8 +33,13 @@
 #include <curses.h>
 #include <bsd_termios.h>
 #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
 # include <termio.h>
-#endif /* #if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
+#endif
+#endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 #ifdef __NetBSD__
 # include <term.h>
 #endif /* ifdef __NetBSD__ */

--- a/ex/ex_script.c
+++ b/ex/ex_script.c
@@ -44,9 +44,14 @@
 # include <util.h>
 #else
 # include <bsd_termios.h>
-# if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
-#  include <termio.h>
-# endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
+#if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ)
+#ifdef __linux__
+# include <termios.h>
+#endif
+#ifndef __linux__
+# include <termio.h>
+#endif
+#endif /* if defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) */
 # include <bsd_unistd.h>
 # include <util.h>
 #endif /* if defined(__OpenBSD__) || defined(__NetBSD__) */


### PR DESCRIPTION
Hello,

It seems termio.h is being replaced on (some?) Linux distros by termios.h (https://tldp.org/LDP/lpg/node143.html).
OpenVi compiles on my system (Ubuntu 25.10) with the changes.